### PR TITLE
minor bug fix in InstrAdd

### DIFF
--- a/src/instructions/InstrAdd.java
+++ b/src/instructions/InstrAdd.java
@@ -47,9 +47,9 @@ public class InstrAdd extends Instr {
 		int result = dst+src;
 		
 		// Set if there was carry from the MSB of the result; cleared otherwise
-        if ( ( (bit7Mask & dst)!=0 && (bit7Mask & src)!=0)
-            || ( (bit7Mask & src)!=0 && (bit7Mask&result)==0 ) 
-		    || ( (bit7Mask&result)==0 && (bit7Mask & dst)!=0 ) 
+        if ( ( (msbMask & dst)!=0 && (msbMask & src)!=0)
+            || ( (msbMask & src)!=0 && (msbMask&result)==0 ) 
+		    || ( (msbMask&result)==0 && (msbMask & dst)!=0 ) 
 		   )
 		{
 			newStatus.setC(true);


### PR DESCRIPTION
I think I found the problematic section in mjsim

In this file
https://github.com/mstrout/mjsim/blob/master/src/instructions/InstrAdd.java

We have the following code
@Override
    public void execute() {
        ....
    // Set if there was carry from the MSB of the result; cleared otherwise
        if ( ( (bit7Mask & dst)!=0 && (bit7Mask & src)!=0)
            || ( (bit7Mask & src)!=0 && (bit7Mask&result)==0 ) 
            || ( (bit7Mask&result)==0 && (bit7Mask & dst)!=0 ) 
           )
        {
            newStatus.setC(true);
        }

bit7Mask is 0x0040

The AVR instruction manual tells us
C: Rd7 & Rr7 + Rr7 & !R7 + R7 & !Rd7
Set if there was carry from the MSB of the result; cleared otherwise.
(Page 16 in the pdf)

The instruction manual uses R0 often, so I'm guessing they labeled the bits with zero based index. This means R7 would refer to the 8th bit, as in 0x0080

So, for the java code, it should be using this guy 
msbMask = 0x0080
rather than the bit7Mask

I did some tests and the following all evaluates to true when using reference compiler and MJSIM.jar to run the AVR code

64+64 == 384
96+32 == 384
65+65 == 386

For all these examples, the 0x0040 bit is set to 1 in both numbers being added. So, the carry bit is incorrectly set and 256 gets added to the answer due to carry bit going into the high 8 bits.

Also, we get 128+128 == 0 as true
This would make sense since 128 has only the 0x0080 bit set, so the 0x0040 bit is 0 and carry bit doesn't get set. So, we get 0000 0000 in low 8 bits due to the carry and since the carry bit is never set, we don't see it propagate into the high 8 bits.

It looks like the wrong mask is used in some other instructions as well
